### PR TITLE
DP-17 Adds local authorities for a county and a city

### DIFF
--- a/Local/Județul Arad/Consiliul Județean Arad/detail.txt
+++ b/Local/Județul Arad/Consiliul Județean Arad/detail.txt
@@ -1,0 +1,9 @@
+{
+  "publish-date-format-static": "d\\.m\\=.Y",
+  "publish-date-css-selector": "#pagContext > div.colRight > div.xSlogan",
+  "attachments": {
+    "link-css-selector": "#pagContext > div.colRight > div.divAttachList > div > span.nDown > a",
+    "title-css-selector": "#pagContext > div.colRight > div.divAttachList > div > span.nFile2"
+  },
+  "title-css-selector": "#pagContext > div.colRight > h1"
+}

--- a/Local/Județul Arad/Consiliul Județean Arad/list.txt
+++ b/Local/Județul Arad/Consiliul Județean Arad/list.txt
@@ -1,0 +1,4 @@
+{
+  "detail-url-css-selector": "#pagContext > div.colRight > div > a",
+  "initial-url": "http://www.cjarad.ro/transparenta/7/"
+}

--- a/Local/Județul Arad/Municipiul Arad/Primăria Municipiului Arad/list.txt
+++ b/Local/Județul Arad/Municipiul Arad/Primăria Municipiului Arad/list.txt
@@ -1,0 +1,4 @@
+{
+  "detail-url-css-selector": "#maxTileTD > a",
+  "initial-url": "http://www.primariaarad.ro/stiri.php?catid=16"
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Indicatii pentru robotul automat de parsare a dezbaterilor publice
 | Entity | Example Formats |
 | ------ | --------------- |
 | Primarie | Primaria Municipiului Cluj-Napoca, Primaria Comunei Bragadiru |
-| Consilii judetene | Consiliul Judetean Arad |
+| Consilii judetene | Consiliul Județean Arad |
 
 # Fisierele din folderul unei autoritati publice
 
@@ -30,6 +30,8 @@ Formatul fisierelor este [JSON](https://www.json.org/json-ro.html). [Link catre 
 | ---- | ----------- |
 | list.txt | Instructiuni specifice descoperirii listei de dezbateri publice; contine pagina de inceput a scanarii, elementele link catre pagina de detaliu a dezbateri publice, elemente de paginare pentru indexarea tuturor paginilor |
 | detail.txt | Instructiuni specifice elementelor dezbaterii publice; contine elementele dezbaterii publice din pagina de detaliu |
+
+Daca un singur element este necesar si selectorul returneaza mai multe elemente, daca acel selector este specific unui element ce are nevoie de textContent, se va extrage tot textContentul din toate elementele returnate. 
 
 # Elemente list.txt
 | Element | Tip | Descriere |


### PR DESCRIPTION
Adds two authorities: Consiliul Judetean Arad and Primaria Municipiului Arad.